### PR TITLE
Updates dependencies to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # weather-tg-bot
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/magicxor/weather-tg-bot)
+
 Inline Telegram weather bot
 
 [Demo](https://github.com/magicxor/weather-tg-bot/assets/8275793/2910b994-d2ef-45b3-bfa8-d3e7df3b916e)

--- a/WeatherTgBot/.editorconfig
+++ b/WeatherTgBot/.editorconfig
@@ -17,6 +17,10 @@ dotnet_diagnostic.CS1998.severity = suggestion
 # Reason: it could be too verbose to use it everywhere, but this is a good reminder
 dotnet_diagnostic.CA1848.severity = suggestion
 
+# CA1873: Evaluation of this argument may be expensive and unnecessary if logging is disabled
+# Reason: logging performance is not critical in our context, and this warning is too aggressive
+dotnet_diagnostic.CA1873.severity = none
+
 # CA1716: Rename namespace Xxx.Shared.Constants so that it no longer conflicts with the reserved language keyword 'Shared'.
 # Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.
 # Reason: we decided to keep it as is for now

--- a/WeatherTgBot/WeatherTgBot/Dockerfile
+++ b/WeatherTgBot/WeatherTgBot/Dockerfile
@@ -1,10 +1,10 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER app
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["WeatherTgBot/WeatherTgBot.csproj", "WeatherTgBot/"]

--- a/WeatherTgBot/WeatherTgBot/WeatherTgBot.csproj
+++ b/WeatherTgBot/WeatherTgBot/WeatherTgBot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <!-- Code analysis -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>9-Recommended</AnalysisLevel>
+    <AnalysisLevel>10-Recommended</AnalysisLevel>
 
     <!-- Warnings and errors -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -33,25 +33,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Flurl" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Refit" Version="8.0.0" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.5.0.109200">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -59,8 +59,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Telegram.Bot" Version="22.3.0" />
-    <PackageReference Include="TimeZoneConverter" Version="7.0.0" />
+    <PackageReference Include="Telegram.Bot" Version="22.7.5" />
+    <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps .NET SDK and ASP.NET versions to 10.0.

Updates various NuGet package references to their latest versions,
including CsvHelper, Microsoft.Extensions.*, NLog, Roslynator.*,
SonarAnalyzer.CSharp, Telegram.Bot, TimeZoneConverter, and Microsoft.VisualStudio.Azure.Containers.Tools.Targets.

Disables CA1873 analyzer due to non-critical logging performance concerns.
